### PR TITLE
Rebuild flight delay map with live updates

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,531 @@
+:root {
+  color-scheme: light dark;
+  --bg-panel: #ffffff;
+  --bg-panel-dark: #0f172a;
+  --text-primary: #0b1a33;
+  --text-secondary: #4a6076;
+  --accent-blue: #2563eb;
+  --accent-green: #2eb872;
+  --accent-yellow: #facc15;
+  --accent-orange: #fb923c;
+  --accent-red: #f87171;
+  --border-color: rgba(15, 23, 42, 0.08);
+  --shadow-color: rgba(15, 23, 42, 0.1);
+  --swatch-on-time: #2eb872;
+  --swatch-low: #facc15;
+  --swatch-medium: #fb923c;
+  --swatch-high: #ef4444;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  min-height: 100vh;
+  color: var(--text-primary);
+  background: #f8fafc;
+}
+
+#map {
+  flex: 1 1 auto;
+  height: 100vh;
+  min-height: 100%;
+  background: #dbeafe;
+}
+
+#info-panel {
+  width: 380px;
+  max-width: 32vw;
+  background: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border-color);
+  box-shadow: -12px 0 24px -22px var(--shadow-color);
+  z-index: 999;
+}
+
+.panel-inner {
+  padding: 1.5rem;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.panel-header h1 {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+#refresh-btn {
+  border: none;
+  background: var(--accent-blue);
+  color: #fff;
+  font-weight: 600;
+  padding: 0.55rem 0.9rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+#refresh-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px -12px rgba(37, 99, 235, 0.6);
+}
+
+#refresh-btn[data-loading="true"] {
+  pointer-events: none;
+  opacity: 0.75;
+}
+
+#refresh-btn .spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #fff;
+  animation: spin 0.65s linear infinite;
+  display: none;
+}
+
+#refresh-btn[data-loading="true"] .spinner {
+  display: inline-flex;
+}
+
+#refresh-btn[data-loading="true"] .label {
+  opacity: 0.7;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.update-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.update-meta .badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.badge.live {
+  background: rgba(46, 184, 114, 0.14);
+  color: var(--accent-green);
+}
+
+.badge.partial {
+  background: rgba(250, 204, 21, 0.16);
+  color: #b45309;
+}
+
+.badge.offline {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+#notification {
+  display: none;
+  background: rgba(248, 113, 113, 0.16);
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.25);
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  font-size: 0.86rem;
+  margin-bottom: 1.5rem;
+}
+
+#selected-airport h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+#selected-airport .airport-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.4rem;
+}
+
+.airport-code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.9rem;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent-blue);
+}
+
+#selected-airport .subtitle {
+  color: var(--text-secondary);
+  margin-top: 0.2rem;
+  margin-bottom: 0.8rem;
+  font-size: 0.95rem;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.subtitle.small {
+  font-size: 0.82rem;
+  margin-bottom: 0.7rem;
+}
+
+.data-source {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--accent-blue);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 1.2rem;
+}
+
+.status-chip[data-state="on-time"] {
+  background: rgba(46, 184, 114, 0.15);
+  color: var(--accent-green);
+}
+
+.status-chip[data-state="minor"] {
+  background: rgba(250, 204, 21, 0.2);
+  color: #b45309;
+}
+
+.status-chip[data-state="moderate"] {
+  background: rgba(251, 146, 60, 0.2);
+  color: #c2410c;
+}
+
+.status-chip[data-state="severe"] {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin-bottom: 1.4rem;
+}
+
+.metric {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.9rem;
+  padding: 0.75rem;
+  background: rgba(248, 250, 252, 0.75);
+}
+
+.metric-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.metric-value {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.status-details {
+  margin-bottom: 1.6rem;
+}
+
+.status-details h3,
+.routes-section h3,
+.legend h3 {
+  margin: 0 0 0.6rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-details p,
+#status-reason {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  line-height: 1.45;
+}
+
+.routes-section {
+  margin-bottom: 1.4rem;
+}
+
+#route-insight {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.route-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.route-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.route-code {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.route-share {
+  font-variant-numeric: tabular-nums;
+}
+
+.route-bar {
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.route-bar span {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: inherit;
+}
+
+.legend {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding-top: 1.2rem;
+  margin-top: auto;
+}
+
+.legend ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.legend .swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+}
+
+.legend .swatch.on-time {
+  background: var(--swatch-on-time);
+}
+
+.legend .swatch.low {
+  background: var(--swatch-low);
+}
+
+.legend .swatch.medium {
+  background: var(--swatch-medium);
+}
+
+.legend .swatch.high {
+  background: var(--swatch-high);
+}
+
+.empty-state {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.leaflet-tooltip {
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(15, 23, 42, 0.92);
+  color: #fff;
+  border-radius: 0.55rem;
+  border: none;
+  box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.7);
+}
+
+.leaflet-tooltip-top:before,
+.leaflet-tooltip-bottom:before,
+.leaflet-tooltip-left:before,
+.leaflet-tooltip-right:before {
+  border-top-color: rgba(15, 23, 42, 0.92);
+}
+
+@media (max-width: 1080px) {
+  #info-panel {
+    width: 320px;
+  }
+  .panel-inner {
+    padding: 1.25rem;
+  }
+}
+
+@media (max-width: 880px) {
+  body {
+    flex-direction: column;
+  }
+
+  #map {
+    height: 55vh;
+    flex: none;
+    order: 2;
+  }
+
+  #info-panel {
+    width: 100%;
+    max-width: none;
+    order: 1;
+    box-shadow: none;
+    border-left: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  }
+
+  .panel-inner {
+    max-height: 45vh;
+  }
+}
+
+@media (max-width: 640px) {
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  }
+
+  #refresh-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0f172a;
+    color: rgba(226, 232, 240, 0.95);
+  }
+
+  #info-panel {
+    background: rgba(15, 23, 42, 0.88);
+    border-left-color: rgba(148, 163, 184, 0.08);
+    box-shadow: -12px 0 24px -22px rgba(0, 0, 0, 0.6);
+  }
+
+  .panel-inner {
+    color: inherit;
+  }
+
+  .panel-header h1,
+  #selected-airport h2 {
+    color: rgba(226, 232, 240, 0.98);
+  }
+
+  #notification {
+    background: rgba(239, 68, 68, 0.16);
+    border-color: rgba(239, 68, 68, 0.3);
+    color: rgba(248, 250, 252, 0.9);
+  }
+
+  .metric {
+    background: rgba(15, 23, 42, 0.65);
+    border-color: rgba(148, 163, 184, 0.12);
+  }
+
+  .metric-value {
+    color: rgba(226, 232, 240, 0.95);
+  }
+
+  .route-bar {
+    background: rgba(226, 232, 240, 0.12);
+  }
+
+  .legend {
+    border-top-color: rgba(148, 163, 184, 0.18);
+  }
+
+  .legend li {
+    color: rgba(226, 232, 240, 0.7);
+  }
+
+  .leaflet-tooltip {
+    background: rgba(15, 23, 42, 0.9);
+  }
+}
+

--- a/assets/js/airportData.js
+++ b/assets/js/airportData.js
@@ -1,0 +1,603 @@
+(function () {
+  const AIRPORT_DATA = {
+    ATL: {
+      code: "ATL",
+      name: "Hartsfield-Jackson Atlanta International Airport",
+      city: "Atlanta, GA",
+      lat: 33.6407,
+      lon: -84.4277,
+      trafficIndex: 6,
+      tracked: true,
+      topRoutes: [
+        { code: "LGA", share: 0.12 },
+        { code: "MCO", share: 0.11 },
+        { code: "LAX", share: 0.08 }
+      ]
+    },
+    LAX: {
+      code: "LAX",
+      name: "Los Angeles International Airport",
+      city: "Los Angeles, CA",
+      lat: 33.9416,
+      lon: -118.4085,
+      trafficIndex: 5,
+      tracked: true,
+      topRoutes: [
+        { code: "SFO", share: 0.1 },
+        { code: "JFK", share: 0.08 },
+        { code: "SEA", share: 0.07 }
+      ]
+    },
+    ORD: {
+      code: "ORD",
+      name: "O'Hare International Airport",
+      city: "Chicago, IL",
+      lat: 41.9742,
+      lon: -87.9073,
+      trafficIndex: 5,
+      tracked: true,
+      topRoutes: [
+        { code: "LGA", share: 0.09 },
+        { code: "DEN", share: 0.08 },
+        { code: "MSP", share: 0.07 }
+      ]
+    },
+    DFW: {
+      code: "DFW",
+      name: "Dallas/Fort Worth International Airport",
+      city: "Dallas-Fort Worth, TX",
+      lat: 32.8998,
+      lon: -97.0403,
+      trafficIndex: 5,
+      tracked: true,
+      topRoutes: [
+        { code: "LAX", share: 0.08 },
+        { code: "ORD", share: 0.07 },
+        { code: "DEN", share: 0.07 }
+      ]
+    },
+    DEN: {
+      code: "DEN",
+      name: "Denver International Airport",
+      city: "Denver, CO",
+      lat: 39.8561,
+      lon: -104.6737,
+      trafficIndex: 5,
+      tracked: true,
+      topRoutes: [
+        { code: "ORD", share: 0.08 },
+        { code: "LAX", share: 0.07 },
+        { code: "PHX", share: 0.06 }
+      ]
+    },
+    JFK: {
+      code: "JFK",
+      name: "John F. Kennedy International Airport",
+      city: "New York, NY",
+      lat: 40.6413,
+      lon: -73.7781,
+      trafficIndex: 4,
+      tracked: true,
+      topRoutes: [
+        { code: "LAX", share: 0.09 },
+        { code: "SFO", share: 0.08 },
+        { code: "MCO", share: 0.07 }
+      ]
+    },
+    SFO: {
+      code: "SFO",
+      name: "San Francisco International Airport",
+      city: "San Francisco, CA",
+      lat: 37.6213,
+      lon: -122.379,
+      trafficIndex: 4,
+      tracked: true,
+      topRoutes: [
+        { code: "LAX", share: 0.14 },
+        { code: "SEA", share: 0.07 },
+        { code: "DEN", share: 0.07 }
+      ]
+    },
+    SEA: {
+      code: "SEA",
+      name: "Seattle-Tacoma International Airport",
+      city: "Seattle, WA",
+      lat: 47.4502,
+      lon: -122.3088,
+      trafficIndex: 4,
+      tracked: true,
+      topRoutes: [
+        { code: "SFO", share: 0.11 },
+        { code: "LAX", share: 0.09 },
+        { code: "DEN", share: 0.06 }
+      ]
+    },
+    MCO: {
+      code: "MCO",
+      name: "Orlando International Airport",
+      city: "Orlando, FL",
+      lat: 28.4312,
+      lon: -81.3081,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "ATL", share: 0.13 },
+        { code: "JFK", share: 0.09 },
+        { code: "EWR", share: 0.07 }
+      ]
+    },
+    LAS: {
+      code: "LAS",
+      name: "Harry Reid International Airport",
+      city: "Las Vegas, NV",
+      lat: 36.084,
+      lon: -115.1537,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "LAX", share: 0.09 },
+        { code: "DEN", share: 0.08 },
+        { code: "SFO", share: 0.07 }
+      ]
+    },
+    BOS: {
+      code: "BOS",
+      name: "Logan International Airport",
+      city: "Boston, MA",
+      lat: 42.3656,
+      lon: -71.0096,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "JFK", share: 0.1 },
+        { code: "DCA", share: 0.08 },
+        { code: "ORD", share: 0.07 }
+      ]
+    },
+    MIA: {
+      code: "MIA",
+      name: "Miami International Airport",
+      city: "Miami, FL",
+      lat: 25.7959,
+      lon: -80.287,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "JFK", share: 0.11 },
+        { code: "ATL", share: 0.09 },
+        { code: "LGA", share: 0.07 }
+      ]
+    },
+    MSP: {
+      code: "MSP",
+      name: "Minneapolis–Saint Paul International Airport",
+      city: "Minneapolis, MN",
+      lat: 44.8848,
+      lon: -93.2223,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "DEN", share: 0.08 },
+        { code: "ORD", share: 0.08 },
+        { code: "ATL", share: 0.06 }
+      ]
+    },
+    DTW: {
+      code: "DTW",
+      name: "Detroit Metropolitan Wayne County Airport",
+      city: "Detroit, MI",
+      lat: 42.2162,
+      lon: -83.3554,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "ORD", share: 0.08 },
+        { code: "JFK", share: 0.07 },
+        { code: "ATL", share: 0.06 }
+      ]
+    },
+    PHX: {
+      code: "PHX",
+      name: "Phoenix Sky Harbor International Airport",
+      city: "Phoenix, AZ",
+      lat: 33.4342,
+      lon: -112.0116,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "DEN", share: 0.09 },
+        { code: "LAX", share: 0.08 },
+        { code: "SFO", share: 0.06 }
+      ]
+    },
+    PHL: {
+      code: "PHL",
+      name: "Philadelphia International Airport",
+      city: "Philadelphia, PA",
+      lat: 39.8744,
+      lon: -75.2424,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "ATL", share: 0.09 },
+        { code: "BOS", share: 0.08 },
+        { code: "MCO", share: 0.07 }
+      ]
+    },
+    EWR: {
+      code: "EWR",
+      name: "Newark Liberty International Airport",
+      city: "Newark, NJ",
+      lat: 40.6895,
+      lon: -74.1745,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "MCO", share: 0.08 },
+        { code: "ATL", share: 0.08 },
+        { code: "SFO", share: 0.07 }
+      ]
+    },
+    CLT: {
+      code: "CLT",
+      name: "Charlotte Douglas International Airport",
+      city: "Charlotte, NC",
+      lat: 35.2144,
+      lon: -80.9473,
+      trafficIndex: 4,
+      tracked: true,
+      topRoutes: [
+        { code: "ATL", share: 0.12 },
+        { code: "JFK", share: 0.07 },
+        { code: "MCO", share: 0.07 }
+      ]
+    },
+    IAH: {
+      code: "IAH",
+      name: "George Bush Intercontinental Airport",
+      city: "Houston, TX",
+      lat: 29.9902,
+      lon: -95.3368,
+      trafficIndex: 4,
+      tracked: true,
+      topRoutes: [
+        { code: "DEN", share: 0.08 },
+        { code: "ATL", share: 0.07 },
+        { code: "ORD", share: 0.07 }
+      ]
+    },
+    LGA: {
+      code: "LGA",
+      name: "LaGuardia Airport",
+      city: "New York, NY",
+      lat: 40.7769,
+      lon: -73.874,
+      trafficIndex: 3,
+      tracked: true,
+      topRoutes: [
+        { code: "ATL", share: 0.12 },
+        { code: "ORD", share: 0.09 },
+        { code: "MIA", share: 0.08 }
+      ]
+    },
+    DCA: {
+      code: "DCA",
+      name: "Ronald Reagan Washington National Airport",
+      city: "Washington, DC",
+      lat: 38.8512,
+      lon: -77.0402,
+      trafficIndex: 2,
+      tracked: false,
+      topRoutes: []
+    }
+  };
+
+  const FALLBACK_DELAY_SNAPSHOT = {
+    ATL: {
+      delay: true,
+      avgDelayMinutes: 32,
+      maxDelayMinutes: 58,
+      minDelayMinutes: 18,
+      reason: "Ground delay program from thunderstorms across northern Georgia.",
+      trend: "Improving",
+      weather: {
+        summary: "Thunderstorms",
+        temperature: "82°F",
+        wind: "SW 12 kt",
+        visibility: "3 mi"
+      },
+      fetchedAt: "2023-07-18T23:05:00Z"
+    },
+    LAX: {
+      delay: true,
+      avgDelayMinutes: 12,
+      maxDelayMinutes: 25,
+      minDelayMinutes: 6,
+      reason: "Low marine layer is slowing arrivals on the south complex.",
+      trend: "Steady",
+      weather: {
+        summary: "Low clouds",
+        temperature: "67°F",
+        wind: "W 9 kt",
+        visibility: "6 mi"
+      },
+      fetchedAt: "2023-07-18T22:45:00Z"
+    },
+    ORD: {
+      delay: true,
+      avgDelayMinutes: 24,
+      maxDelayMinutes: 44,
+      minDelayMinutes: 12,
+      reason: "Low ceilings and traffic volume creating an arrival metering program.",
+      trend: "Rising",
+      weather: {
+        summary: "Overcast",
+        temperature: "71°F",
+        wind: "NE 8 kt",
+        visibility: "5 mi"
+      },
+      fetchedAt: "2023-07-18T23:15:00Z"
+    },
+    DFW: {
+      delay: true,
+      avgDelayMinutes: 16,
+      maxDelayMinutes: 34,
+      minDelayMinutes: 8,
+      reason: "Thunderstorm cells in the departure corridor.",
+      trend: "Improving",
+      weather: {
+        summary: "Scattered storms",
+        temperature: "86°F",
+        wind: "S 14 kt",
+        visibility: "8 mi"
+      },
+      fetchedAt: "2023-07-18T22:58:00Z"
+    },
+    DEN: {
+      delay: true,
+      avgDelayMinutes: 8,
+      maxDelayMinutes: 18,
+      minDelayMinutes: 4,
+      reason: "Gusty winds are extending taxi-out times.",
+      trend: "Steady",
+      weather: {
+        summary: "Windy",
+        temperature: "79°F",
+        wind: "NW 18 kt",
+        visibility: "10 mi"
+      },
+      fetchedAt: "2023-07-18T22:40:00Z"
+    },
+    JFK: {
+      delay: true,
+      avgDelayMinutes: 28,
+      maxDelayMinutes: 52,
+      minDelayMinutes: 16,
+      reason: "Ground delay program because of evening thunderstorms over Long Island.",
+      trend: "Rising",
+      weather: {
+        summary: "Thunderstorms",
+        temperature: "79°F",
+        wind: "S 11 kt",
+        visibility: "4 mi"
+      },
+      fetchedAt: "2023-07-18T23:10:00Z"
+    },
+    SFO: {
+      delay: true,
+      avgDelayMinutes: 35,
+      maxDelayMinutes: 62,
+      minDelayMinutes: 20,
+      reason: "Low ceilings require single runway operations.",
+      trend: "Steady",
+      weather: {
+        summary: "Fog",
+        temperature: "61°F",
+        wind: "W 16 kt",
+        visibility: "2 mi"
+      },
+      fetchedAt: "2023-07-18T21:55:00Z"
+    },
+    SEA: {
+      delay: true,
+      avgDelayMinutes: 6,
+      maxDelayMinutes: 14,
+      minDelayMinutes: 3,
+      reason: "Low clouds and runway construction reducing capacity.",
+      trend: "Improving",
+      weather: {
+        summary: "Low clouds",
+        temperature: "64°F",
+        wind: "S 6 kt",
+        visibility: "7 mi"
+      },
+      fetchedAt: "2023-07-18T22:30:00Z"
+    },
+    MCO: {
+      delay: true,
+      avgDelayMinutes: 18,
+      maxDelayMinutes: 36,
+      minDelayMinutes: 10,
+      reason: "Pop-up storms south of Orlando slowing departures.",
+      trend: "Steady",
+      weather: {
+        summary: "Thunderstorms",
+        temperature: "84°F",
+        wind: "SE 9 kt",
+        visibility: "5 mi"
+      },
+      fetchedAt: "2023-07-18T22:20:00Z"
+    },
+    LAS: {
+      delay: true,
+      avgDelayMinutes: 10,
+      maxDelayMinutes: 21,
+      minDelayMinutes: 5,
+      reason: "High winds producing occasional ground stops.",
+      trend: "Improving",
+      weather: {
+        summary: "Windy",
+        temperature: "96°F",
+        wind: "SW 22 kt",
+        visibility: "10 mi"
+      },
+      fetchedAt: "2023-07-18T22:05:00Z"
+    },
+    BOS: {
+      delay: true,
+      avgDelayMinutes: 22,
+      maxDelayMinutes: 41,
+      minDelayMinutes: 12,
+      reason: "Low ceilings and volume creating arrival metering.",
+      trend: "Steady",
+      weather: {
+        summary: "Low clouds",
+        temperature: "68°F",
+        wind: "NE 10 kt",
+        visibility: "4 mi"
+      },
+      fetchedAt: "2023-07-18T22:55:00Z"
+    },
+    MIA: {
+      delay: true,
+      avgDelayMinutes: 14,
+      maxDelayMinutes: 30,
+      minDelayMinutes: 7,
+      reason: "Tropical showers south of the field slowing departures.",
+      trend: "Steady",
+      weather: {
+        summary: "Showers",
+        temperature: "86°F",
+        wind: "E 13 kt",
+        visibility: "6 mi"
+      },
+      fetchedAt: "2023-07-18T22:12:00Z"
+    },
+    MSP: {
+      delay: true,
+      avgDelayMinutes: 7,
+      maxDelayMinutes: 15,
+      minDelayMinutes: 3,
+      reason: "Northwest winds forcing longer taxi routes.",
+      trend: "Improving",
+      weather: {
+        summary: "Windy",
+        temperature: "72°F",
+        wind: "NW 17 kt",
+        visibility: "10 mi"
+      },
+      fetchedAt: "2023-07-18T22:18:00Z"
+    },
+    DTW: {
+      delay: true,
+      avgDelayMinutes: 9,
+      maxDelayMinutes: 19,
+      minDelayMinutes: 4,
+      reason: "Tower staffing program moderating departures.",
+      trend: "Steady",
+      weather: {
+        summary: "Overcast",
+        temperature: "73°F",
+        wind: "NE 9 kt",
+        visibility: "5 mi"
+      },
+      fetchedAt: "2023-07-18T22:24:00Z"
+    },
+    PHX: {
+      delay: true,
+      avgDelayMinutes: 5,
+      maxDelayMinutes: 12,
+      minDelayMinutes: 2,
+      reason: "Summer heat slowing ramp operations.",
+      trend: "Steady",
+      weather: {
+        summary: "Hot",
+        temperature: "103°F",
+        wind: "SW 6 kt",
+        visibility: "8 mi"
+      },
+      fetchedAt: "2023-07-18T21:58:00Z"
+    },
+    PHL: {
+      delay: true,
+      avgDelayMinutes: 19,
+      maxDelayMinutes: 37,
+      minDelayMinutes: 9,
+      reason: "Thunderstorms west of the airport creating reroutes.",
+      trend: "Rising",
+      weather: {
+        summary: "Storms nearby",
+        temperature: "78°F",
+        wind: "SW 15 kt",
+        visibility: "5 mi"
+      },
+      fetchedAt: "2023-07-18T23:02:00Z"
+    },
+    EWR: {
+      delay: true,
+      avgDelayMinutes: 30,
+      maxDelayMinutes: 55,
+      minDelayMinutes: 18,
+      reason: "Arrival holding due to thunderstorms over New Jersey.",
+      trend: "Rising",
+      weather: {
+        summary: "Thunderstorms",
+        temperature: "78°F",
+        wind: "S 14 kt",
+        visibility: "3 mi"
+      },
+      fetchedAt: "2023-07-18T23:07:00Z"
+    },
+    CLT: {
+      delay: true,
+      avgDelayMinutes: 12,
+      maxDelayMinutes: 25,
+      minDelayMinutes: 6,
+      reason: "Flow control from convective activity in the Carolinas.",
+      trend: "Steady",
+      weather: {
+        summary: "Storms",
+        temperature: "83°F",
+        wind: "SW 12 kt",
+        visibility: "6 mi"
+      },
+      fetchedAt: "2023-07-18T22:35:00Z"
+    },
+    IAH: {
+      delay: true,
+      avgDelayMinutes: 8,
+      maxDelayMinutes: 17,
+      minDelayMinutes: 4,
+      reason: "Gulf moisture and ramp restrictions.",
+      trend: "Improving",
+      weather: {
+        summary: "Humid",
+        temperature: "88°F",
+        wind: "SE 10 kt",
+        visibility: "7 mi"
+      },
+      fetchedAt: "2023-07-18T22:08:00Z"
+    },
+    LGA: {
+      delay: true,
+      avgDelayMinutes: 27,
+      maxDelayMinutes: 48,
+      minDelayMinutes: 14,
+      reason: "Evening thunderstorms causing ground delay programs.",
+      trend: "Rising",
+      weather: {
+        summary: "Thunderstorms",
+        temperature: "77°F",
+        wind: "S 16 kt",
+        visibility: "4 mi"
+      },
+      fetchedAt: "2023-07-18T23:12:00Z"
+    }
+  };
+
+  window.AIRPORT_DATA = AIRPORT_DATA;
+  window.TRACKED_AIRPORT_CODES = Object.values(AIRPORT_DATA)
+    .filter((entry) => entry.tracked)
+    .map((entry) => entry.code);
+  window.FALLBACK_DELAY_SNAPSHOT = FALLBACK_DELAY_SNAPSHOT;
+})();

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,680 @@
+(function () {
+  const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+  const REQUEST_TIMEOUT_MS = 6000;
+  const FAA_ENDPOINT_BUILDERS = [
+    (code) => `https://services.faa.gov/airport/status/${code}?format=application/json`,
+    (code) => `https://cors.isomorphic-git.org/https://services.faa.gov/airport/status/${code}?format=application/json`,
+    (code) => `https://thingproxy.freeboard.io/fetch/https://services.faa.gov/airport/status/${code}?format=application/json`
+  ];
+
+  const airports = window.AIRPORT_DATA || {};
+  const trackedCodes = window.TRACKED_AIRPORT_CODES || [];
+  const fallbackSnapshot = window.FALLBACK_DELAY_SNAPSHOT || {};
+
+  const statusCache = new Map();
+  const markers = new Map();
+
+  let selectedAirportCode = null;
+  let initialSelectionCompleted = false;
+
+  const map = L.map("map", {
+    center: [39.5, -98.35],
+    zoom: 4,
+    minZoom: 3,
+    maxZoom: 9,
+    zoomSnap: 0.25,
+    preferCanvas: true,
+    worldCopyJump: false
+  });
+
+  const tileLayer = L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png", {
+    attribution:
+      "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">Carto</a>",
+    maxZoom: 19
+  });
+  tileLayer.addTo(map);
+
+  map.createPane("routes");
+  map.getPane("routes").style.zIndex = 350;
+  map.createPane("airportMarkers");
+  map.getPane("airportMarkers").style.zIndex = 400;
+
+  const routeLayer = L.layerGroup([], { pane: "routes" }).addTo(map);
+
+  L.control.zoom({ position: "topright" }).addTo(map);
+  L.control.scale({ position: "bottomleft", maxWidth: 120, imperial: true, metric: false }).addTo(map);
+
+  const refreshButton = document.getElementById("refresh-btn");
+  const lastUpdatedEl = document.getElementById("last-updated");
+  const liveIndicatorEl = document.getElementById("live-indicator");
+  const notificationEl = document.getElementById("notification");
+  const airportCodeEl = document.getElementById("airport-code");
+  const airportNameEl = document.getElementById("airport-name");
+  const airportLocationEl = document.getElementById("airport-location");
+  const delayChipEl = document.getElementById("delay-chip");
+  const avgDelayEl = document.getElementById("avg-delay");
+  const maxDelayEl = document.getElementById("max-delay");
+  const minDelayEl = document.getElementById("min-delay");
+  const trendEl = document.getElementById("delay-trend");
+  const weatherEl = document.getElementById("weather-summary");
+  const weatherWindEl = document.getElementById("weather-wind");
+  const airportUpdatedEl = document.getElementById("airport-updated");
+  const statusReasonEl = document.getElementById("status-reason");
+  const routeContainerEl = document.getElementById("route-insight");
+
+  trackedCodes.forEach((code) => {
+    const airport = airports[code];
+    if (!airport) {
+      return;
+    }
+
+    const marker = L.circleMarker([airport.lat, airport.lon], {
+      radius: computeMarkerRadius(airport),
+      color: "#64748b",
+      weight: 2,
+      opacity: 1,
+      fillColor: "#64748b",
+      fillOpacity: 0.85,
+      pane: "airportMarkers"
+    })
+      .addTo(map)
+      .bindTooltip(buildTooltipContent(airport, null), { direction: "top", sticky: true, opacity: 0.92 });
+
+    marker.on("click", () => focusOnAirport(code, { flyTo: true }));
+    markers.set(code, marker);
+  });
+
+  fitMapToAirports();
+  refreshButton?.addEventListener("click", () => refreshData({ forceSelect: false, userInitiated: true }));
+  refreshData({ forceSelect: true });
+  setInterval(() => refreshData({ forceSelect: false }), REFRESH_INTERVAL_MS);
+
+  function fitMapToAirports() {
+    const bounds = L.latLngBounds([]);
+    trackedCodes.forEach((code) => {
+      const airport = airports[code];
+      if (!airport) return;
+      bounds.extend([airport.lat, airport.lon]);
+    });
+    if (bounds.isValid()) {
+      map.fitBounds(bounds, { padding: [36, 36] });
+    }
+  }
+
+  async function refreshData({ forceSelect = false, userInitiated = false } = {}) {
+    if (!trackedCodes.length) {
+      return;
+    }
+
+    setLoadingState(true);
+
+    const fetchPromises = trackedCodes.map((code) => fetchAirportStatus(code));
+    const results = await Promise.allSettled(fetchPromises);
+
+    let liveCount = 0;
+    results.forEach((result, index) => {
+      const code = trackedCodes[index];
+      let status;
+
+      if (result.status === "fulfilled" && result.value) {
+        status = result.value;
+        liveCount += 1;
+      } else {
+        status = buildFallbackStatus(code);
+      }
+
+      statusCache.set(code, status);
+      updateMarkerAppearance(code, status);
+    });
+
+    updateDataHealth(liveCount, trackedCodes.length);
+    updateLastUpdated(userInitiated);
+
+    if (!initialSelectionCompleted || forceSelect || !selectedAirportCode) {
+      selectAirportWithGreatestDelay();
+      initialSelectionCompleted = true;
+    } else if (selectedAirportCode) {
+      focusOnAirport(selectedAirportCode, { flyTo: false });
+    }
+
+    setLoadingState(false);
+  }
+
+  function setLoadingState(isLoading) {
+    if (!refreshButton) return;
+    if (isLoading) {
+      refreshButton.setAttribute("data-loading", "true");
+    } else {
+      refreshButton.removeAttribute("data-loading");
+    }
+  }
+
+  async function fetchAirportStatus(code) {
+    for (const builder of FAA_ENDPOINT_BUILDERS) {
+      const url = builder(code);
+      try {
+        const response = await fetchWithTimeout(url, { timeout: REQUEST_TIMEOUT_MS });
+        if (!response.ok) {
+          continue;
+        }
+        const data = await response.json();
+        return parseFaaStatus(code, data);
+      } catch (error) {
+        // Try next endpoint
+      }
+    }
+    throw new Error(`Unable to retrieve status for ${code}`);
+  }
+
+  function fetchWithTimeout(url, { timeout = REQUEST_TIMEOUT_MS } = {}) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+    return fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: "application/json"
+      }
+    }).finally(() => clearTimeout(timer));
+  }
+
+  function parseFaaStatus(code, data) {
+    const status = data?.status || {};
+    const weather = data?.weather || {};
+    const avgDelay = parseDelayMinutes(status.avgDelay);
+    const maxDelay = parseDelayMinutes(status.maxDelay);
+    const minDelay = parseDelayMinutes(status.minDelay);
+
+    const delayFlag = normalizeBoolean(data?.delay) || avgDelay > 0;
+    const reason = cleanText(status.reason || status.type) || (delayFlag ? "Delays reported" : "No major delays reported.");
+    const trend = cleanText(status.trend);
+    const fetchedAt = normalizeTimestamp(status.updateTime) || new Date().toISOString();
+
+    const weatherSummary = cleanText(weather.weather || weather.conditions);
+    const temperature = cleanText(weather.temp || weather.temperature);
+    const wind = cleanText(weather.wind);
+    const visibility = normalizeVisibility(weather.visibility);
+
+    return createStatusObject(code, {
+      delay: delayFlag,
+      avgDelayMinutes: avgDelay,
+      maxDelayMinutes: maxDelay,
+      minDelayMinutes: minDelay,
+      reason,
+      trend,
+      weather: {
+        summary: weatherSummary,
+        temperature,
+        wind,
+        visibility
+      },
+      fetchedAt,
+      live: true
+    });
+  }
+
+  function buildFallbackStatus(code) {
+    const fallback = fallbackSnapshot[code];
+    if (!fallback) {
+      return createStatusObject(code, {
+        delay: false,
+        avgDelayMinutes: 0,
+        maxDelayMinutes: 0,
+        minDelayMinutes: 0,
+        reason: "Live FAA status is unavailable for this airport.",
+        trend: "",
+        weather: {
+          summary: "",
+          temperature: "",
+          wind: "",
+          visibility: ""
+        },
+        fetchedAt: null,
+        live: false
+      });
+    }
+
+    return createStatusObject(code, {
+      delay: fallback.delay,
+      avgDelayMinutes: fallback.avgDelayMinutes,
+      maxDelayMinutes: fallback.maxDelayMinutes,
+      minDelayMinutes: fallback.minDelayMinutes,
+      reason: fallback.reason,
+      trend: fallback.trend,
+      weather: {
+        summary: fallback.weather?.summary,
+        temperature: fallback.weather?.temperature,
+        wind: fallback.weather?.wind,
+        visibility: fallback.weather?.visibility
+      },
+      fetchedAt: fallback.fetchedAt,
+      live: false
+    });
+  }
+
+  function createStatusObject(code, overrides) {
+    const delay = Boolean(overrides.delay) || (overrides.avgDelayMinutes || 0) > 0;
+    return {
+      code,
+      delay,
+      avgDelayMinutes: normalizeNumber(overrides.avgDelayMinutes),
+      maxDelayMinutes: normalizeNumber(overrides.maxDelayMinutes),
+      minDelayMinutes: normalizeNumber(overrides.minDelayMinutes),
+      reason: cleanText(overrides.reason) || (delay ? "Delays reported." : "No significant delays reported."),
+      trend: cleanText(overrides.trend),
+      weather: {
+        summary: cleanText(overrides.weather?.summary),
+        temperature: cleanText(overrides.weather?.temperature),
+        wind: cleanText(overrides.weather?.wind),
+        visibility: cleanText(overrides.weather?.visibility)
+      },
+      fetchedAt: overrides.fetchedAt || null,
+      live: Boolean(overrides.live)
+    };
+  }
+
+  function updateMarkerAppearance(code, status) {
+    const airport = airports[code];
+    const marker = markers.get(code);
+    if (!airport || !marker) return;
+
+    const severity = determineSeverity(status);
+    const color = colorForSeverity(severity);
+
+    marker.setStyle({
+      color,
+      fillColor: color,
+      fillOpacity: 0.9,
+      weight: selectedAirportCode === code ? 4 : 2,
+      radius: computeMarkerRadius(airport) + (selectedAirportCode === code ? 1.6 : 0)
+    });
+
+    const tooltip = buildTooltipContent(airport, status);
+    if (typeof marker.setTooltipContent === "function") {
+      marker.setTooltipContent(tooltip);
+    } else {
+      marker.bindTooltip(tooltip, { direction: "top", sticky: true, opacity: 0.92 });
+    }
+  }
+
+  function buildTooltipContent(airport, status) {
+    const headline = `<strong>${airport.code}</strong> · ${airport.city}`;
+    if (!status) {
+      return `<div class="tooltip"><div>${headline}</div><div>Loading status…</div></div>`;
+    }
+    const severityLabel = status.delay
+      ? `${status.avgDelayMinutes ? `${status.avgDelayMinutes} min avg delay` : "Delay reported"}`
+      : "On time";
+    const sourceLabel = status.live ? "Live FAA feed" : "Snapshot";
+    return `<div class="tooltip"><div>${headline}</div><div>${escapeHtml(severityLabel)}</div><div>${sourceLabel}</div></div>`;
+  }
+
+  function focusOnAirport(code, { flyTo = false } = {}) {
+    const airport = airports[code];
+    if (!airport) return;
+    selectedAirportCode = code;
+
+    const status = statusCache.get(code) || buildFallbackStatus(code);
+    updateInfoPanel(airport, status);
+    drawRoutesForAirport(airport);
+
+    markers.forEach((marker, markerCode) => {
+      const severity = statusCache.get(markerCode) || buildFallbackStatus(markerCode);
+      marker.setStyle({
+        weight: markerCode === code ? 4 : 2,
+        radius: computeMarkerRadius(airports[markerCode]) + (markerCode === code ? 1.6 : 0),
+        color: colorForSeverity(determineSeverity(severity)),
+        fillColor: colorForSeverity(determineSeverity(severity))
+      });
+      if (markerCode === code) {
+        marker.bringToFront();
+      }
+    });
+
+    if (flyTo) {
+      map.flyTo([airport.lat, airport.lon], Math.max(map.getZoom(), 5.2), { duration: 0.9 });
+    }
+  }
+
+  function selectAirportWithGreatestDelay() {
+    let bestCode = trackedCodes[0];
+    let highestDelay = -1;
+
+    trackedCodes.forEach((code) => {
+      const status = statusCache.get(code);
+      const delay = status?.avgDelayMinutes ?? 0;
+      if (delay > highestDelay) {
+        highestDelay = delay;
+        bestCode = code;
+      }
+    });
+
+    focusOnAirport(bestCode, { flyTo: false });
+  }
+
+  function updateInfoPanel(airport, status) {
+    airportCodeEl.textContent = airport.code;
+    airportNameEl.textContent = airport.name;
+    airportLocationEl.textContent = airport.city;
+
+    const severity = determineSeverity(status);
+    delayChipEl.dataset.state = severity;
+    delayChipEl.textContent = severityLabel(severity);
+
+    avgDelayEl.textContent = formatMinutes(status.avgDelayMinutes);
+    maxDelayEl.textContent = formatMinutes(status.maxDelayMinutes);
+    minDelayEl.textContent = formatMinutes(status.minDelayMinutes);
+    trendEl.textContent = status.trend || "—";
+
+    const weatherParts = [status.weather.summary, status.weather.temperature, status.weather.visibility]
+      .filter(Boolean)
+      .join(" · ");
+    weatherEl.textContent = weatherParts || "Not reported";
+    weatherWindEl.textContent = status.weather.wind ? `Wind ${status.weather.wind}` : "";
+
+    statusReasonEl.textContent = status.reason;
+
+    if (status.fetchedAt) {
+      const localTime = formatTimestamp(status.fetchedAt);
+      airportUpdatedEl.textContent = status.live ? `Live update ${localTime}` : `Snapshot from ${localTime}`;
+    } else {
+      airportUpdatedEl.textContent = status.live ? "Live data" : "Snapshot data";
+    }
+
+    renderRouteList(airport);
+  }
+
+  function renderRouteList(airport) {
+    if (!routeContainerEl) return;
+    routeContainerEl.innerHTML = "";
+
+    if (!airport.topRoutes || airport.topRoutes.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "empty-state";
+      empty.textContent = "No route insight available.";
+      routeContainerEl.appendChild(empty);
+      return;
+    }
+
+    const maxShare = Math.max(...airport.topRoutes.map((route) => route.share));
+    airport.topRoutes.forEach((route) => {
+      const destination = airports[route.code];
+      if (!destination) return;
+
+      const row = document.createElement("div");
+      row.className = "route-row";
+
+      const meta = document.createElement("div");
+      meta.className = "route-meta";
+      const codeEl = document.createElement("span");
+      codeEl.className = "route-code";
+      codeEl.textContent = `${airport.code} → ${route.code}`;
+      const shareEl = document.createElement("span");
+      shareEl.className = "route-share";
+      shareEl.textContent = `${Math.round(route.share * 100)}% of delays`;
+      meta.appendChild(codeEl);
+      meta.appendChild(shareEl);
+
+      const bar = document.createElement("div");
+      bar.className = "route-bar";
+      const fill = document.createElement("span");
+      fill.style.width = `${Math.max(12, (route.share / maxShare) * 100)}%`;
+      fill.style.background = colorForRouteShare(route.share);
+      bar.appendChild(fill);
+
+      row.appendChild(meta);
+      row.appendChild(bar);
+      routeContainerEl.appendChild(row);
+    });
+  }
+
+  function drawRoutesForAirport(airport) {
+    routeLayer.clearLayers();
+    if (!airport.topRoutes || airport.topRoutes.length === 0) return;
+
+    airport.topRoutes.forEach((route) => {
+      const destination = airports[route.code];
+      if (!destination) return;
+
+      const arcPoints = buildGreatCircleArc(
+        [airport.lat, airport.lon],
+        [destination.lat, destination.lon],
+        64
+      );
+
+      const color = colorForRouteShare(route.share);
+      L.polyline(arcPoints, {
+        color,
+        weight: 2.5 + route.share * 8,
+        opacity: 0.75,
+        pane: "routes"
+      }).addTo(routeLayer);
+    });
+  }
+
+  function updateDataHealth(liveCount, total) {
+    if (!liveIndicatorEl) return;
+    const fallbackCount = total - liveCount;
+
+    if (liveCount === total) {
+      liveIndicatorEl.textContent = "Live FAA feed";
+      liveIndicatorEl.className = "badge live";
+      hideNotification();
+    } else if (liveCount === 0) {
+      liveIndicatorEl.textContent = "Offline snapshot";
+      liveIndicatorEl.className = "badge offline";
+      showNotification(
+        "FAA status feed is unreachable. Displaying the latest historical snapshot so you still have situational awareness."
+      );
+    } else {
+      liveIndicatorEl.textContent = `Partial live (${liveCount}/${total})`;
+      liveIndicatorEl.className = "badge partial";
+      showNotification(
+        `${fallbackCount} airport${fallbackCount > 1 ? "s" : ""} are using historical delay data because the live feed is unavailable.`
+      );
+    }
+  }
+
+  function hideNotification() {
+    if (!notificationEl) return;
+    notificationEl.style.display = "none";
+    notificationEl.textContent = "";
+  }
+
+  function showNotification(message) {
+    if (!notificationEl) return;
+    notificationEl.style.display = "block";
+    notificationEl.textContent = message;
+  }
+
+  function updateLastUpdated(userInitiated) {
+    if (!lastUpdatedEl) return;
+    const now = new Date();
+    const formatted = now.toLocaleString([], {
+      hour: "numeric",
+      minute: "2-digit",
+      month: "short",
+      day: "numeric"
+    });
+    lastUpdatedEl.textContent = `Updated ${formatted}${userInitiated ? " (manual refresh)" : ""}`;
+  }
+
+  function computeMarkerRadius(airport) {
+    const index = airport?.trafficIndex ?? 3;
+    return 6 + Math.min(index, 6) * 1.7;
+  }
+
+  function determineSeverity(status) {
+    if (!status || !status.delay) {
+      return "on-time";
+    }
+    const avg = status.avgDelayMinutes || 0;
+    if (avg < 10) return "minor";
+    if (avg < 25) return "moderate";
+    return "severe";
+  }
+
+  function severityLabel(severity) {
+    switch (severity) {
+      case "minor":
+        return "Minor delays";
+      case "moderate":
+        return "Moderate delays";
+      case "severe":
+        return "Severe delays";
+      default:
+        return "On time";
+    }
+  }
+
+  function colorForSeverity(severity) {
+    switch (severity) {
+      case "minor":
+        return "#facc15";
+      case "moderate":
+        return "#fb923c";
+      case "severe":
+        return "#ef4444";
+      default:
+        return "#2eb872";
+    }
+  }
+
+  function colorForRouteShare(share) {
+    const clamped = Math.min(Math.max(share, 0.04), 0.18);
+    const t = (clamped - 0.04) / (0.18 - 0.04);
+    return interpolateColor("#2563eb", "#ef4444", t);
+  }
+
+  function interpolateColor(startHex, endHex, t) {
+    const start = hexToRgb(startHex);
+    const end = hexToRgb(endHex);
+    const r = Math.round(start.r + (end.r - start.r) * t);
+    const g = Math.round(start.g + (end.g - start.g) * t);
+    const b = Math.round(start.b + (end.b - start.b) * t);
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+
+  function hexToRgb(hex) {
+    const normalized = hex.replace("#", "");
+    const bigint = parseInt(normalized, 16);
+    return {
+      r: (bigint >> 16) & 255,
+      g: (bigint >> 8) & 255,
+      b: bigint & 255
+    };
+  }
+
+  function formatMinutes(value) {
+    if (value === null || value === undefined || Number.isNaN(value)) {
+      return "—";
+    }
+    if (value === 0) {
+      return "0 min";
+    }
+    return `${value} min`;
+  }
+
+  function formatTimestamp(isoString) {
+    try {
+      const date = new Date(isoString);
+      if (Number.isNaN(date.getTime())) return isoString;
+      return date.toLocaleString([], { hour: "numeric", minute: "2-digit", month: "short", day: "numeric" });
+    } catch (error) {
+      return isoString;
+    }
+  }
+
+  function buildGreatCircleArc(start, end, steps = 64) {
+    const [lat1, lon1] = start.map(toRadians);
+    const [lat2, lon2] = end.map(toRadians);
+
+    const d = 2 * Math.asin(
+      Math.sqrt(
+        Math.sin((lat2 - lat1) / 2) ** 2 +
+          Math.cos(lat1) * Math.cos(lat2) * Math.sin((lon2 - lon1) / 2) ** 2
+      )
+    );
+
+    if (d === 0) {
+      return [start, end];
+    }
+
+    const points = [];
+    for (let i = 0; i <= steps; i += 1) {
+      const f = i / steps;
+      const A = Math.sin((1 - f) * d) / Math.sin(d);
+      const B = Math.sin(f * d) / Math.sin(d);
+
+      const x = A * Math.cos(lat1) * Math.cos(lon1) + B * Math.cos(lat2) * Math.cos(lon2);
+      const y = A * Math.cos(lat1) * Math.sin(lon1) + B * Math.cos(lat2) * Math.sin(lon2);
+      const z = A * Math.sin(lat1) + B * Math.sin(lat2);
+
+      const lat = Math.atan2(z, Math.sqrt(x * x + y * y));
+      const lon = Math.atan2(y, x);
+      points.push([toDegrees(lat), toDegrees(lon)]);
+    }
+    return points;
+  }
+
+  function toRadians(deg) {
+    return (deg * Math.PI) / 180;
+  }
+
+  function toDegrees(rad) {
+    return (rad * 180) / Math.PI;
+  }
+
+  function parseDelayMinutes(value) {
+    if (value === null || value === undefined) return 0;
+    if (typeof value === "number" && !Number.isNaN(value)) return Math.round(value);
+    const text = String(value).trim();
+    if (!text || text.toLowerCase() === "na" || text.toLowerCase() === "n/a") return 0;
+    const match = text.match(/([0-9]+)\s*(min|minute)/i);
+    if (match) {
+      return parseInt(match[1], 10);
+    }
+    const numeric = parseInt(text, 10);
+    return Number.isNaN(numeric) ? 0 : numeric;
+  }
+
+  function normalizeBoolean(value) {
+    if (typeof value === "boolean") return value;
+    if (typeof value === "string") {
+      const lower = value.toLowerCase();
+      return lower === "true" || lower === "yes";
+    }
+    return false;
+  }
+
+  function normalizeTimestamp(value) {
+    if (!value) return null;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toISOString();
+  }
+
+  function normalizeVisibility(value) {
+    if (!value && value !== 0) return "";
+    const text = String(value).trim();
+    if (!text) return "";
+    if (text.toLowerCase().includes("mi")) return text;
+    return `${text} mi`;
+  }
+
+  function normalizeNumber(value) {
+    if (value === null || value === undefined) return 0;
+    const num = Number(value);
+    if (Number.isNaN(num)) return 0;
+    return Math.round(num);
+  }
+
+  function cleanText(value) {
+    if (typeof value !== "string") return "";
+    return value.replace(/\s+/g, " ").trim();
+  }
+
+  function escapeHtml(value) {
+    if (typeof value !== "string") return value;
+    return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+})();


### PR DESCRIPTION
## Summary
- replace the static folium export with a hand-built Leaflet app that fetches FAA status data on an interval
- add a responsive insights panel with live delay metrics, weather context, and dynamic severity badges
- visualize historically delayed routes for each hub with on-map great-circle arcs and proportional bar indicators

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c886d5fb8883209ddf380c2a235caa